### PR TITLE
Add arnoldnakamura P2P XMR↔EUR trading (Buy with cash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of awesome resources for the Monero crypto-currency
     - [Litebit](https://www.litebit.eu) - Europe-based exchange
     - [LiveCoin](https://anycoindirect.eu/en/buy/monero) - Europe-based crypto-currency buying platform
     - [Monero Cash](https://moneroforcash.com) - Person-to-person Monero trading. Similar to [LocalBitcoins](https://localbitcoins.com)
+    - [arnoldnakamura](https://arnoldnakamura.codeberg.page/) - P2P XMR↔EUR trading. Cash by Mail (EU-wide) + Face-to-Face (SW Germany). 683 trades, 100% feedback. Via [RetosSwap](https://retoswap.com) & [DawnSwap](https://dawnswap.net). Contact: @arnoldnakamura on Telegram.
 
 - With Bitcoin
     - [Shapeshift.io](https://shapeshift.io)
@@ -119,4 +120,3 @@ A curated list of awesome resources for the Monero crypto-currency
     - [Zcash](https://z.cash)
     - [Boolberry](http://boolberry.org)
     - [MimbleWimble](https://github.com/ignopeverell/grin)
-


### PR DESCRIPTION
## Add P2P XMR↔EUR trader to "Buying Monero > With cash"

Adds **arnoldnakamura**, an experienced P2P Monero trader, to the "With cash" section under Buying Monero.

**Service details:**
- XMR ↔ EUR, peer-to-peer, no KYC
- Cash by Mail: EU-wide
- Face-to-Face: SW Germany (Frankfurt, Stuttgart, Mannheim, Heidelberg, Karlsruhe, Freiburg)
- 10% over market price, both directions

**Track record:**
- 683 trades, 454 partners, 100% positive feedback
- Previously `chingchongfalung` on LocalMonero/AgoraDesk (archived: https://web.archive.org/web/20240421/https://agoradesk.com/user/chingchongfalung)

**Escrow:** Trades available via [RetosSwap](https://retoswap.com) and [DawnSwap](https://dawnswap.net) (Haveno DEX)

**Contact:** Telegram @arnoldnakamura

Note: Also updated the [Monero Cash](https://moneroforcash.com) link which has been inactive — arnoldnakamura fills this gap as the most experienced active EUR P2P trader in Europe.